### PR TITLE
refactor config options to follow mimir/loki's `role-X` pattern

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -54,25 +54,94 @@ resources:
 
 config:
   options:
-    role:
+    role-all:
+      type: boolean
+      default: true
       description: |
-        The role that this tempo worker will run with.
-        Possible roles are:
-          - "all" # default, mapped to internal "scalable-single-binary" target in tempo workload
-          - "querier"
-          - "query-frontend"
-          - "ingester"
-          - "distributor"
-          - "compactor"
-          - "metrics-generator"
-        Note that for a tempo deployment to be valid, each one of these roles needs to be
-        assigned to at least one worker node. Or, at least one node need to have the "all" role.
-        Also note that in the distributed tempo configuration, the `all` role translates into `scalable-single-binary`, 
-        effectively hiding the original Tempo `all` role (meaning non-scalable single monolithic binary). This choice 
-        was made to keep design compatibility with other distributed observability charms (mimir, loki).
-      type: string
-      default: all
+        Configure the application to run with all roles enabled. This is the default configuration. 
+        This is a meta-role that configures the application to enable all other roles. Under the hood, the `all` role
+        is mapped to Tempo's `scalable-single-binary`.
+             
+        Each Tempo application can only have exactly one `role-X` config set to `true` at any given time. 
+        So if you want to configure this app to run with a role other than `all`, remember to set `all` to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
+    role-querier:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    role-query-frontend:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    role-ingester:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    role-distributor:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    role-compactor:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+
+    role-metrics-generator:
+      type: boolean
+      default: false
+      description: |
+        Configure the application to run as this Tempo role. Each Tempo application can only have exactly one 
+        `role-X` config set to `true`. So if you want to enable a role, remember to set all other roles to `false`.
+        Invalid configurations will result in the component to stop working and the app to set blocked status.
+        
+        Note that for a tempo deployment as a whole to be consistent, each role 
+        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        is not met, the coordinator charm will set blocked status and the deployment will shut down.
+        
 
 # build info
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -67,7 +67,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-querier:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -79,7 +79,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-query-frontend:
@@ -91,7 +91,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-ingester:
@@ -103,7 +103,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-distributor:
@@ -115,7 +115,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-compactor:
@@ -127,7 +127,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
 
     role-metrics-generator:
@@ -139,7 +139,7 @@ config:
         Invalid configurations will result in the component to stop working and the app to set blocked status.
         
         Note that for a tempo deployment as a whole to be consistent, each role 
-        (except the optional 'query-frontend') needs to be assigned to at least one worker node. If this condition
+        (except the optional 'metrics-generator') needs to be assigned to at least one worker node. If this condition
         is not met, the coordinator charm will set blocked status and the deployment will shut down.
         
 

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -172,14 +172,65 @@ needs to be replaced with:
 provide an *absolute* path to the certificate file instead.
 """
 
+
+def _remove_stale_otel_sdk_packages():
+    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
+
+    See https://github.com/canonical/grafana-agent-operator/issues/146 and
+    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
+    this juju issue is resolved and sufficient time has passed to expect most users of this library
+    have migrated to the patched version of juju.  When this patch is removed, un-ignore rule E402 for this file in the pyproject.toml (see setting
+    [tool.ruff.lint.per-file-ignores] in pyproject.toml).
+
+    This only has an effect if executed on an upgrade-charm event.
+    """
+    # all imports are local to keep this function standalone, side-effect-free, and easy to revert later
+    import os
+
+    if os.getenv("JUJU_DISPATCH_PATH") != "hooks/upgrade-charm":
+        return
+
+    import logging
+    import shutil
+    from collections import defaultdict
+
+    from importlib_metadata import distributions
+
+    otel_logger = logging.getLogger("charm_tracing_otel_patcher")
+    otel_logger.debug("Applying _remove_stale_otel_sdk_packages patch on charm upgrade")
+    # group by name all distributions starting with "opentelemetry_"
+    otel_distributions = defaultdict(list)
+    for distribution in distributions():
+        name = distribution._normalized_name  # type: ignore
+        if name.startswith("opentelemetry_"):
+            otel_distributions[name].append(distribution)
+
+    otel_logger.debug(f"Found {len(otel_distributions)} opentelemetry distributions")
+
+    # If we have multiple distributions with the same name, remove any that have 0 associated files
+    for name, distributions_ in otel_distributions.items():
+        if len(distributions_) <= 1:
+            continue
+
+        otel_logger.debug(f"Package {name} has multiple ({len(distributions_)}) distributions.")
+        for distribution in distributions_:
+            if not distribution.files:  # Not None or empty list
+                path = distribution._path  # type: ignore
+                otel_logger.info(f"Removing empty distribution of {name} at {path}.")
+                shutil.rmtree(path)
+
+    otel_logger.debug("Successfully applied _remove_stale_otel_sdk_packages patch. ")
+
+
+_remove_stale_otel_sdk_packages()
+
+
 import functools
 import inspect
 import logging
 import os
-import shutil
 from contextlib import contextmanager
 from contextvars import Context, ContextVar, copy_context
-from importlib.metadata import distributions
 from pathlib import Path
 from typing import (
     Any,
@@ -199,14 +250,15 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, Tracer
-from opentelemetry.trace import get_current_span as otlp_get_current_span
 from opentelemetry.trace import (
+    INVALID_SPAN,
+    Tracer,
     get_tracer,
     get_tracer_provider,
     set_span_in_context,
     set_tracer_provider,
 )
+from opentelemetry.trace import get_current_span as otlp_get_current_span
 from ops.charm import CharmBase
 from ops.framework import Framework
 
@@ -219,7 +271,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 12
+LIBPATCH = 14
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -361,30 +413,6 @@ def _get_server_cert(
     return server_cert
 
 
-def _remove_stale_otel_sdk_packages():
-    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
-
-    See https://github.com/canonical/grafana-agent-operator/issues/146 and
-    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
-    this juju issue is resolved and sufficient time has passed to expect most users of this library
-    have migrated to the patched version of juju.
-
-    This only does something if executed on an upgrade-charm event.
-    """
-    if os.getenv("JUJU_DISPATCH_PATH") == "hooks/upgrade-charm":
-        logger.debug("Executing _remove_stale_otel_sdk_packages patch on charm upgrade")
-        # Find any opentelemetry_sdk distributions
-        otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
-        # If there is more than 1, inspect each and if it has 0 entrypoints, infer that it is stale
-        if len(otel_sdk_distributions) > 1:
-            for distribution in otel_sdk_distributions:
-                if len(distribution.entry_points) == 0:
-                    # Distribution appears to be empty. Remove it
-                    path = distribution._path  # type: ignore
-                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {path}")
-                    shutil.rmtree(path)
-
-
 def _setup_root_span_initializer(
     charm_type: _CharmType,
     tracing_endpoint_attr: str,
@@ -420,7 +448,6 @@ def _setup_root_span_initializer(
         # apply hacky patch to remove stale opentelemetry sdk packages on upgrade-charm.
         # it could be trouble if someone ever decides to implement their own tracer parallel to
         # ours and before the charm has inited. We assume they won't.
-        _remove_stale_otel_sdk_packages()
         resource = Resource.create(
             attributes={
                 "service.name": _service_name,
@@ -642,38 +669,58 @@ def trace_type(cls: _T) -> _T:
             dev_logger.info(f"skipping {method} (dunder)")
             continue
 
-        new_method = trace_method(method)
-        if isinstance(inspect.getattr_static(cls, method.__name__), staticmethod):
+        # the span title in the general case should be:
+        #   method call: MyCharmWrappedMethods.b
+        # if the method has a name (functools.wrapped or regular method), let
+        # _trace_callable use its default algorithm to determine what name to give the span.
+        trace_method_name = None
+        try:
+            qualname_c0 = method.__qualname__.split(".")[0]
+            if not hasattr(cls, method.__name__):
+                # if the callable doesn't have a __name__ (probably a decorated method),
+                # it probably has a bad qualname too (such as my_decorator.<locals>.wrapper) which is not
+                # great for finding out what the trace is about. So we use the method name instead and
+                # add a reference to the decorator name. Result:
+                #   method call: @my_decorator(MyCharmWrappedMethods.b)
+                trace_method_name = f"@{qualname_c0}({cls.__name__}.{name})"
+        except Exception:  # noqa: failsafe
+            pass
+
+        new_method = trace_method(method, name=trace_method_name)
+
+        if isinstance(inspect.getattr_static(cls, name), staticmethod):
             new_method = staticmethod(new_method)
         setattr(cls, name, new_method)
 
     return cls
 
 
-def trace_method(method: _F) -> _F:
+def trace_method(method: _F, name: Optional[str] = None) -> _F:
     """Trace this method.
 
     A span will be opened when this method is called and closed when it returns.
     """
-    return _trace_callable(method, "method")
+    return _trace_callable(method, "method", name=name)
 
 
-def trace_function(function: _F) -> _F:
+def trace_function(function: _F, name: Optional[str] = None) -> _F:
     """Trace this function.
 
     A span will be opened when this function is called and closed when it returns.
     """
-    return _trace_callable(function, "function")
+    return _trace_callable(function, "function", name=name)
 
 
-def _trace_callable(callable: _F, qualifier: str) -> _F:
+def _trace_callable(callable: _F, qualifier: str, name: Optional[str] = None) -> _F:
     dev_logger.info(f"instrumenting {callable}")
 
     # sig = inspect.signature(callable)
     @functools.wraps(callable)
     def wrapped_function(*args, **kwargs):  # type: ignore
-        name = getattr(callable, "__qualname__", getattr(callable, "__name__", str(callable)))
-        with _span(f"{qualifier} call: {name}"):  # type: ignore
+        name_ = name or getattr(
+            callable, "__qualname__", getattr(callable, "__name__", str(callable))
+        )
+        with _span(f"{qualifier} call: {name_}"):  # type: ignore
             return callable(*args, **kwargs)  # type: ignore
 
     # wrapped_function.__signature__ = sig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.0
+ops >= 2.15
 cosl>=0.0.19
 
 # Charm relation interfaces

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 2.15
-cosl>=0.0.19
+cosl>=0.0.20
 
 # Charm relation interfaces
 pydantic>=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
-cosl
+cosl>=0.0.19
 
 # Charm relation interfaces
 pydantic>=2

--- a/tests/scenario/helpers.py
+++ b/tests/scenario/helpers.py
@@ -1,0 +1,12 @@
+import scenario
+
+from charm import TempoWorkerK8SOperatorCharm
+
+
+def set_role(state: scenario.State, role: str):
+    """Modify a state to activate a tempo role."""
+    cfg = {}
+    for role_ in TempoWorkerK8SOperatorCharm._valid_roles:
+        cfg[f"role-{role_}"] = False
+    cfg[f"role-{role}"] = True
+    return state.replace(config=cfg)

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -30,8 +30,7 @@ def test_status_cannot_connect(ctx, evt):
     state_out = ctx.run(
         evt,
         state=State(
-            config={"role-ingester": True,
-                    "role-all": False},
+            config={"role-ingester": True, "role-all": False},
             containers=[container],
             relations=[Relation("tempo-cluster")],
         ),
@@ -110,7 +109,9 @@ def test_pebble_ready_plan(ctx, role):
                         },
                     )
                 ],
-            ), role),
+            ),
+            role,
+        ),
     )
 
     tempo_container_out = state_out.get_container(tempo_container)
@@ -126,13 +127,13 @@ def test_pebble_ready_plan(ctx, role):
 @pytest.mark.parametrize(
     "role_str, expected",
     (
-            ("all", "all"),
-            ("querier", "querier"),
-            ("query-frontend", "query-frontend"),
-            ("ingester", "ingester"),
-            ("distributor", "distributor"),
-            ("compactor", "compactor"),
-            ("metrics-generator", "metrics-generator"),
+        ("all", "all"),
+        ("querier", "querier"),
+        ("query-frontend", "query-frontend"),
+        ("ingester", "ingester"),
+        ("distributor", "distributor"),
+        ("compactor", "compactor"),
+        ("metrics-generator", "metrics-generator"),
     ),
 )
 def test_role(ctx, role_str, expected):
@@ -144,7 +145,8 @@ def test_role(ctx, role_str, expected):
                 containers=[Container("tempo", can_connect=True)],
                 relations=[Relation("tempo-cluster")],
             ),
-            role_str),
+            role_str,
+        ),
     )
     if expected:
         data = ClusterRequirerAppData.load(out.get_relations("tempo-cluster")[0].local_app_data)


### PR DESCRIPTION
testing instructions:

```
juju deploy cos-lite --channel edge
# configure facade to present s3
juju deploy facade --channel edge
cat << EOF > ./s3.yaml
endpoint: provide-s3
app_data: |
  {
    "access-key": "mykey",
    "bucket": "BuckyMcBucket",
    "endpoint": "http://1.2.3.4:9000",
    "secret-key": "soverysecret"
  }
EOF
juju run facade/0 update --params ./s3.yaml 
rm ./s3.yaml

juju deploy tempo-coordinator-k8s-operator --channel edge tempo

charmcraft pack
jhack deploy  # deploy from local

jhack imatrix fill
```

At this point you should have:

![image](https://github.com/user-attachments/assets/0c0aae9b-8eee-49de-8f08-7453f3a3d2ea)


