### PR TITLE
Shorten charm title as charmcraft doesn't fetch libraries

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,7 +3,7 @@
 
 type: charm
 name: tempo-worker-k8s
-title: Tempo Charmed Operator [distributed mode] worker node
+title: Tempo Charmed Operator worker node
 
 assumes:
   - k8s-api


### PR DESCRIPTION
## Issue
`charmcraft fetch-lib` stopped working in this charm with this error:

```
$ charmcraft fetch-lib
Bad charmcraft.yaml content:
- ensure this value has at most 40 characters (in field 'title')
```

## Solution
Shorten charm title to less than 40 characters.


## Context
:facepalm: 


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
