### PR TITLE
checks for worker readiness

### DIFF
--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,13 +1,20 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
 import pytest
-from charm import TempoWorkerK8SOperatorCharm
 from scenario import Context, ExecOutput
 
+from charm import TempoWorkerK8SOperatorCharm
 
-@pytest.fixture(autouse=True)
-def patch_all():
-    # with patch("charm.TempoWorkerK8SOperatorCharm._current_tempo_config", PropertyMock(return_value={})):
-    # with patch("charm.TempoWorkerK8SOperatorCharm._set_alerts", Mock(return_value=True)):
-    yield
+
+@contextmanager
+def _urlopen_patch(url: str, resp):
+    if url == "http://localhost:3200/ready":
+        mm = MagicMock()
+        mm.read = MagicMock(return_value=resp.encode("utf-8"))
+        yield mm
+    else:
+        raise RuntimeError("unknown path")
 
 
 @pytest.fixture

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -134,13 +134,13 @@ def test_pebble_ready_plan(ctx, role):
 @pytest.mark.parametrize(
     "role_str, expected",
     (
-            ("all", "all"),
-            ("querier", "querier"),
-            ("query-frontend", "query-frontend"),
-            ("ingester", "ingester"),
-            ("distributor", "distributor"),
-            ("compactor", "compactor"),
-            ("metrics-generator", "metrics-generator"),
+        ("all", "all"),
+        ("querier", "querier"),
+        ("query-frontend", "query-frontend"),
+        ("ingester", "ingester"),
+        ("distributor", "distributor"),
+        ("compactor", "compactor"),
+        ("metrics-generator", "metrics-generator"),
     ),
 )
 def test_role(ctx, role_str, expected):

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 import json
+from functools import partial
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -8,8 +9,14 @@ from cosl.coordinated_workers.interface import ClusterRequirerAppData, ClusterRe
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from scenario import Container, ExecOutput, Relation, State
 
-from tests.scenario.conftest import TEMPO_VERSION_EXEC_OUTPUT
+from tests.scenario.conftest import TEMPO_VERSION_EXEC_OUTPUT, _urlopen_patch
 from tests.scenario.helpers import set_role
+
+
+@pytest.fixture(autouse=True)
+def patch_all():
+    with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
+        yield
 
 
 @pytest.mark.parametrize("evt", ["update-status", "config-changed"])
@@ -127,13 +134,13 @@ def test_pebble_ready_plan(ctx, role):
 @pytest.mark.parametrize(
     "role_str, expected",
     (
-        ("all", "all"),
-        ("querier", "querier"),
-        ("query-frontend", "query-frontend"),
-        ("ingester", "ingester"),
-        ("distributor", "distributor"),
-        ("compactor", "compactor"),
-        ("metrics-generator", "metrics-generator"),
+            ("all", "all"),
+            ("querier", "querier"),
+            ("query-frontend", "query-frontend"),
+            ("ingester", "ingester"),
+            ("distributor", "distributor"),
+            ("compactor", "compactor"),
+            ("metrics-generator", "metrics-generator"),
     ),
 )
 def test_role(ctx, role_str, expected):

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -1,6 +1,5 @@
-from contextlib import contextmanager
 from functools import partial
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from cosl.coordinated_workers.interface import ClusterProviderAppData
@@ -8,6 +7,7 @@ from ops import ActiveStatus, WaitingStatus
 from scenario import Context, State, Container, Relation
 
 from charm import TempoWorkerK8SOperatorCharm
+from tests.scenario.conftest import _urlopen_patch
 
 
 @pytest.fixture
@@ -15,28 +15,17 @@ def ctx():
     return Context(TempoWorkerK8SOperatorCharm)
 
 
-@contextmanager
-def _urlopen_patch(url: str, resp):
-    if url == "http://localhost:3200/ready":
-        mm = MagicMock()
-        mm.read = MagicMock(return_value=resp.encode('utf-8'))
-        yield mm
-    else:
-        raise RuntimeError("unknown path")
-
-
 def test_status_check_starting(ctx):
     # GIVEN getting the status returns "Starting: X"
     db = {}
     ClusterProviderAppData(worker_config="foo:12").dump(db)
 
-    with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="foo\nStarting: 10\n bar")):
-
+    with patch(
+            "urllib.request.urlopen", new=partial(_urlopen_patch, resp="foo\nStarting: 10\n bar")
+    ):
         state = State(
-            relations=[
-                Relation("tempo-cluster",
-                         remote_app_data=db)],
-            containers=[Container("tempo", can_connect=True)]
+            relations=[Relation("tempo-cluster", remote_app_data=db)],
+            containers=[Container("tempo", can_connect=True)],
         )
         # WHEN we run any event
         state_out = ctx.run("update_status", state)
@@ -51,13 +40,10 @@ def test_status_check_ready(ctx):
 
     with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
         state = State(
-            relations=[
-                Relation("tempo-cluster",
-                         remote_app_data=db)],
-            containers=[Container("tempo", can_connect=True)]
+            relations=[Relation("tempo-cluster", remote_app_data=db)],
+            containers=[Container("tempo", can_connect=True)],
         )
         # WHEN we run any event
         state_out = ctx.run("update_status", state)
     # THEN the charm sets waiting: Starting...
     assert state_out.unit_status == ActiveStatus("(all roles) ready.")
-

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -21,7 +21,7 @@ def test_status_check_starting(ctx):
     ClusterProviderAppData(worker_config="foo:12").dump(db)
 
     with patch(
-            "urllib.request.urlopen", new=partial(_urlopen_patch, resp="foo\nStarting: 10\n bar")
+        "urllib.request.urlopen", new=partial(_urlopen_patch, resp="foo\nStarting: 10\n bar")
     ):
         state = State(
             relations=[Relation("tempo-cluster", remote_app_data=db)],

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -1,0 +1,63 @@
+from contextlib import contextmanager
+from functools import partial
+from unittest.mock import patch, MagicMock
+
+import pytest
+from cosl.coordinated_workers.interface import ClusterProviderAppData
+from ops import ActiveStatus, WaitingStatus
+from scenario import Context, State, Container, Relation
+
+from charm import TempoWorkerK8SOperatorCharm
+
+
+@pytest.fixture
+def ctx():
+    return Context(TempoWorkerK8SOperatorCharm)
+
+
+@contextmanager
+def _urlopen_patch(url: str, resp):
+    if url == "http://localhost:3200/ready":
+        mm = MagicMock()
+        mm.read = MagicMock(return_value=resp.encode('utf-8'))
+        yield mm
+    else:
+        raise RuntimeError("unknown path")
+
+
+def test_status_check_starting(ctx):
+    # GIVEN getting the status returns "Starting: X"
+    db = {}
+    ClusterProviderAppData(worker_config="foo:12").dump(db)
+
+    with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="foo\nStarting: 10\n bar")):
+
+        state = State(
+            relations=[
+                Relation("tempo-cluster",
+                         remote_app_data=db)],
+            containers=[Container("tempo", can_connect=True)]
+        )
+        # WHEN we run any event
+        state_out = ctx.run("update_status", state)
+    # THEN the charm sets waiting: Starting...
+    assert state_out.unit_status == WaitingStatus("Starting...")
+
+
+def test_status_check_ready(ctx):
+    # GIVEN getting the status returns "ready"
+    db = {}
+    ClusterProviderAppData(worker_config="foo:12").dump(db)
+
+    with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
+        state = State(
+            relations=[
+                Relation("tempo-cluster",
+                         remote_app_data=db)],
+            containers=[Container("tempo", can_connect=True)]
+        )
+        # WHEN we run any event
+        state_out = ctx.run("update_status", state)
+    # THEN the charm sets waiting: Starting...
+    assert state_out.unit_status == ActiveStatus("(all roles) ready.")
+


### PR DESCRIPTION
## Issue
Fixes #20 


## Solution
This PR adds a pebble check that curls localhost:3200/ready and sets status according to the response:
Waiting if the status looks like:
```                                                   
root@tempo-worker-0:/# curl localhost:3200/ready   
Some services are not Running:                     
Running: 16                                        
Starting: 1                                        
```                                               
and Blocked if any non-2xx code is returned or anything weird happens.

