### PR TITLE
Bump `cosl`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops>=2.15
-cosl>=0.0.27
+cosl>=0.0.28
 
 # Charm relation interfaces
 pydantic>=2

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -198,7 +198,14 @@ def test_config_juju_topology(topology_mock, role_str, ctx, tmp_path):
     state = State(
         leader=True,
         containers=[
-            Container("tempo", can_connect=True, mounts={"cfg": Mount(CONFIG_FILE, cfg_file)})
+            Container(
+                "tempo",
+                can_connect=True,
+                mounts={"cfg": Mount(CONFIG_FILE, cfg_file)},
+                exec_mock={
+                    ("update-ca-certificates", "--fresh"): ExecOutput(),
+                },
+            )
         ],
         relations=[cluster_relation],
     )


### PR DESCRIPTION
Bump `cosl` version to `0.0.28` that includes TLS pebble checks fix to fix Tempo Coordinator integration tests.