### PR TITLE
Upgrade interface test fixtures to scenario 7

### DIFF
--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -58,7 +58,7 @@ def interface_tester(interface_tester: InterfaceTester):
                                     Container(
                                         name="tempo",
                                         can_connect=True,
-                                        mounts={"worker-config": Mount(CONFIG_FILE, conf_file)},
+                                        mounts={"worker-config": Mount(location=CONFIG_FILE, source=conf_file)},
                                         exec_mock={
                                             Exec(("update-ca-certificates", "--fresh")),
                                         },

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -59,7 +59,7 @@ def interface_tester(interface_tester: InterfaceTester):
                                         name="tempo",
                                         can_connect=True,
                                         mounts={"worker-config": Mount(location=CONFIG_FILE, source=conf_file)},
-                                        exec_mock={
+                                        execs={
                                             Exec(("update-ca-certificates", "--fresh")),
                                         },
                                     )

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
 from interface_tester import InterfaceTester
 from ops import ActiveStatus
-from scenario import Container, Mount, State, ExecOutput
+from scenario import Container, Mount, State, Exec
 from unittest.mock import MagicMock
 from cosl.coordinated_workers.worker import CONFIG_FILE
 
@@ -60,7 +60,7 @@ def interface_tester(interface_tester: InterfaceTester):
                                         can_connect=True,
                                         mounts={"worker-config": Mount(CONFIG_FILE, conf_file)},
                                         exec_mock={
-                                            ("update-ca-certificates", "--fresh"): ExecOutput(),
+                                            Exec(("update-ca-certificates", "--fresh")),
                                         },
                                     )
                                 ],

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -49,7 +49,7 @@ def interface_tester(interface_tester: InterfaceTester):
         get_status=lambda _: ActiveStatus(""),
         is_ready=k8s_resource_patch_ready,
     ):
-        with patch("cosl.coordinated_workers.worker.check_readiness", new ):
+        with patch("cosl.coordinated_workers.worker.check_readiness", new=readiness_check):
             with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
                 with patch("lightkube.core.client.GenericSyncClient"):
                     with patch("subprocess.run"):

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -12,11 +12,12 @@ from interface_tester import InterfaceTester
 from ops import ActiveStatus
 from scenario import Container, Mount, State, Exec
 from unittest.mock import MagicMock
-from cosl.coordinated_workers.worker import CONFIG_FILE
+from cosl.coordinated_workers.worker import CONFIG_FILE, ServiceEndpointStatus
 
 from charm import TempoWorkerK8SOperatorCharm
 
 k8s_resource_patch_ready = MagicMock(return_value=True)
+readiness_check = MagicMock(return_value=ServiceEndpointStatus.up)
 
 @contextmanager
 def _urlopen_patch(url: str, resp, tls: bool = False):
@@ -48,24 +49,25 @@ def interface_tester(interface_tester: InterfaceTester):
         get_status=lambda _: ActiveStatus(""),
         is_ready=k8s_resource_patch_ready,
     ):
-        with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
-            with patch("lightkube.core.client.GenericSyncClient"):
-                with patch("subprocess.run"):
-                    with charm_tracing_disabled():
-                        interface_tester.configure(
-                            charm_type=TempoWorkerK8SOperatorCharm,
-                            state_template=State(
-                                leader=True,
-                                containers=[
-                                    Container(
-                                        name="tempo",
-                                        can_connect=True,
-                                        mounts={"worker-config": Mount(location=CONFIG_FILE, source=conf_file)},
-                                        execs={
-                                            Exec(("update-ca-certificates", "--fresh")),
-                                        },
-                                    )
-                                ],
-                            ),
-                        )
-                        yield interface_tester
+        with patch("cosl.coordinated_workers.worker.check_readiness", new ):
+            with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
+                with patch("lightkube.core.client.GenericSyncClient"):
+                    with patch("subprocess.run"):
+                        with charm_tracing_disabled():
+                            interface_tester.configure(
+                                charm_type=TempoWorkerK8SOperatorCharm,
+                                state_template=State(
+                                    leader=True,
+                                    containers=[
+                                        Container(
+                                            name="tempo",
+                                            can_connect=True,
+                                            mounts={"worker-config": Mount(location=CONFIG_FILE, source=conf_file)},
+                                            execs={
+                                                Exec(("update-ca-certificates", "--fresh")),
+                                            },
+                                        )
+                                    ],
+                                ),
+                            )
+                            yield interface_tester

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -12,11 +12,12 @@ from interface_tester import InterfaceTester
 from ops import ActiveStatus
 from scenario import Container, Mount, State, Exec
 from unittest.mock import MagicMock
-from cosl.coordinated_workers.worker import CONFIG_FILE, ServiceEndpointStatus
+from cosl.coordinated_workers.worker import CONFIG_FILE
 
 from charm import TempoWorkerK8SOperatorCharm
 
 k8s_resource_patch_ready = MagicMock(return_value=True)
+
 
 @contextmanager
 def _urlopen_patch(url: str, resp, tls: bool = False):
@@ -60,7 +61,11 @@ def interface_tester(interface_tester: InterfaceTester):
                                     Container(
                                         name="tempo",
                                         can_connect=True,
-                                        mounts={"worker-config": Mount(location=CONFIG_FILE, source=conf_file)},
+                                        mounts={
+                                            "worker-config": Mount(
+                                                location=CONFIG_FILE, source=conf_file
+                                            )
+                                        },
                                         execs={
                                             Exec(("update-ca-certificates", "--fresh")),
                                         },

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -16,6 +16,7 @@ from cosl.coordinated_workers.worker import CONFIG_FILE
 
 from charm import TempoWorkerK8SOperatorCharm
 
+k8s_resource_patch_ready = MagicMock(return_value=True)
 
 @contextmanager
 def _urlopen_patch(url: str, resp, tls: bool = False):
@@ -45,6 +46,7 @@ def interface_tester(interface_tester: InterfaceTester):
         _namespace="test-namespace",
         _patch=lambda _: None,
         get_status=lambda _: ActiveStatus(""),
+        is_ready=k8s_resource_patch_ready,
     ):
         with patch("urllib.request.urlopen", new=partial(_urlopen_patch, resp="ready")):
             with patch("lightkube.core.client.GenericSyncClient"):


### PR DESCRIPTION
## Issue
With upgrade to scenario 7, fixtures in interface tests started failing.


## Solution
Upgrade fixtures to scenario 7.


## Context
https://github.com/canonical/charm-relation-interfaces/pull/174


## Testing Instructions
In the context of `charm-relation-interfaces` repo, run:
```
tox -e run-interface-test-matrix -- --include tempo_cluster --repo https://github.com/mmkay/charm-relation-interfaces.git --branch k8s-patch-fix
```

## Release Notes
<!-- A digestable summary of the change in this PR -->
