### PR TITLE
do not generate a worker layer if the app is a metrics generator and we don't have a relation to prom

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,6 @@ from ops.charm import CharmBase
 from ops.main import main
 from ops.model import BlockedStatus, ActiveStatus
 from ops.pebble import Layer
-from scenario.runtime import Runtime
 
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 
@@ -38,6 +37,7 @@ class RolesConfigurationError(Exception):
 
 class TempoWorker(Worker):
     """A Tempo worker class that inherits from the Worker class."""
+
     SERVICE_START_RETRY_STOP = tenacity.stop_after_delay(60)
     SERVICE_START_RETRY_WAIT = tenacity.wait_fixed(5)
 
@@ -169,12 +169,13 @@ class TempoWorkerK8SOperatorCharm(CharmBase):
             # verify we have a metrics storage path configured, else
             # Tempo will fail to start with a bad error.
             if not self.worker.cluster.get_remote_write_endpoints():
-                logger.error("cannot start this metrics-generator node without remote-write endpoints."
-                             "Please relate the coordinator with a prometheus instance.")
+                logger.error(
+                    "cannot start this metrics-generator node without remote-write endpoints."
+                    "Please relate the coordinator with a prometheus instance."
+                )
                 # this will tell the Worker that something is wrong and this node can't be started
                 # update-status will inform the user of what's going on
                 raise MetricsGeneratorStoragePathMissing()
-
 
         return Layer(
             {

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from functools import partial
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from ops import ActiveStatus
@@ -136,4 +136,6 @@ def test_blocked_config_generator_no_config(ctx):
             with pytest.raises(MetricsGeneratorStoragePathMissing):
                 mgr.charm.generate_worker_layer(mgr.charm.worker)
 
-        assert state_out.unit_status == BlockedStatus("No prometheus remote-write relation configured on the coordinator")
+        assert state_out.unit_status == BlockedStatus(
+            "No prometheus remote-write relation configured on the coordinator"
+        )


### PR DESCRIPTION
what the title says

also, speeds up the restart-retry delay to 1 minute, retry every 5 seconds.