### PR TITLE
Update versions.tf

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = "~> 0.14"
     }
   }
 }


### PR DESCRIPTION
We need to use `~> 0.14` and not `~> 0.14.0`

If we use `0.14.0` we are not able to use `0.15` in other modules

Ref: https://developer.hashicorp.com/terraform/language/expressions/version-constraints#-3