### PR TITLE
Add  `juju_` prefix to the labels on metrics from `metrics-generator`

### DIFF
--- a/src/tempo.py
+++ b/src/tempo.py
@@ -71,9 +71,12 @@ class TempoWorker(Worker):
         if "metrics_generator" in config:
             if "registry" not in config["metrics_generator"]:
                 config["metrics_generator"]["registry"] = {}
-            config["metrics_generator"]["registry"]["external_labels"] = dict(
-                self.cluster.juju_topology.as_dict()
-            )
+            labels = {
+                "juju_{}".format(key): value
+                for key, value in self.cluster.juju_topology.as_dict().items()
+                if value
+            }
+            config["metrics_generator"]["registry"]["external_labels"] = labels
 
         return config
 

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -217,8 +217,13 @@ def test_config_juju_topology(topology_mock, role_str, ctx, tmp_path):
 
     # assert that topology is added to config
     updated_config = yaml.safe_load(cfg_file.read_text())
+    expected_labels = {
+        "juju_model": "test",
+        "juju_model_uuid": "00000000-0000-4000-8000-000000000000",
+        "juju_application": "worker",
+        "juju_unit": "worker/0",
+        "juju_charm_name": "tempo",
+    }
     assert updated_config == {
-        "metrics_generator": {
-            "registry": {"external_labels": dict(charm_topo.as_dict())}
-        }
+        "metrics_generator": {"registry": {"external_labels": expected_labels}}
     }


### PR DESCRIPTION
## Issue
Fixes #41 


## Solution
format labels to contain `juju_` prefix.


## Testing Instructions
1- Deploy Tempo HA with this worker
2- Deploy prometheus-k8s
3- integrate coordinator with prometheus over remote-write-endpoint
4- Deploy grafana-k8s
5- integrate grafana and prometheus over grafana-source
6- open grafana UI
7- open sources and check metrics that start with span-, you'll see labels with the prefix


