### PR TITLE
Refactor `metrics-generator` restart logic

### DIFF
--- a/src/tempo.py
+++ b/src/tempo.py
@@ -66,7 +66,7 @@ class TempoWorker(Worker):
         # as it will never start and we'll be stuck executing the hook.
         # Exit and let collect-unit-status set the charm to blocked.
         roles = self.roles
-        if len(roles) > 0 and "metrics-generator" in roles:
+        if "metrics-generator" in (roles or ()):
             if not self.cluster.get_remote_write_endpoints():
                 logger.error(
                     "cannot start this metrics-generator node without remote-write endpoints."

--- a/src/tempo.py
+++ b/src/tempo.py
@@ -20,10 +20,6 @@ class TempoError(Exception):
     """Base class for custom errors raised by this module."""
 
 
-class MetricsGeneratorStoragePathMissing(TempoError):
-    """Raised if the worker node is a metrics-generator and we are missing some config."""
-
-
 class RolesConfigurationError(TempoError):
     """Raised when the worker has an invalid role(s) set in its config."""
 
@@ -64,6 +60,21 @@ class TempoWorker(Worker):
 
         return config
 
+    def restart(self):
+        """Override the worker's restart logic."""
+        # if we don't have the remote-write endpoints, don't try to restart the Tempo service
+        # as it will never start and we'll be stuck executing the hook.
+        # Exit and let collect-unit-status set the charm to blocked.
+        roles = self.roles
+        if len(roles) > 0 and "metrics-generator" in roles:
+            if not self.cluster.get_remote_write_endpoints():
+                logger.error(
+                    "cannot start this metrics-generator node without remote-write endpoints."
+                    "Please relate the coordinator with a prometheus instance."
+                )
+                return
+        super().restart()
+
     def _add_juju_topology(self, config: Dict[str, Any]):
         """Modify the worker config to add juju topology for `metrics-generator`'s generated metrics."""
         # if `metrics_generator` doesn't exist in config,
@@ -95,17 +106,6 @@ class TempoWorker(Worker):
         role = roles[0]
         if role == "all":
             role = "scalable-single-binary"
-        elif role == "metrics-generator":
-            # verify we have a metrics storage path configured, else
-            # Tempo will fail to start with a bad error.
-            if not worker.cluster.get_remote_write_endpoints():
-                logger.error(
-                    "cannot start this metrics-generator node without remote-write endpoints."
-                    "Please relate the coordinator with a prometheus instance."
-                )
-                # this will tell the Worker that something is wrong and this node can't be started
-                # update-status will inform the user of what's going on
-                raise MetricsGeneratorStoragePathMissing()
 
         # Configure Tempo workload traces
         env = {}

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -7,7 +7,6 @@ from ops import ActiveStatus
 from ops import BlockedStatus
 from scenario import State, Container, Relation
 
-from tempo import MetricsGeneratorStoragePathMissing
 from tests.unit.conftest import _urlopen_patch
 import json
 
@@ -137,12 +136,9 @@ def test_blocked_config_generator_no_config(ctx):
     )
 
     with endpoint_ready(), config_on_disk():
-        with ctx(
+        state_out = ctx.run(
             ctx.on.collect_unit_status(), set_role(state, "metrics-generator")
-        ) as mgr:
-            state_out = mgr.run()
-            with pytest.raises(MetricsGeneratorStoragePathMissing):
-                mgr.charm.worker._layer(mgr.charm.worker)
+        )
 
         assert state_out.unit_status == BlockedStatus(
             "No prometheus remote-write relation configured on the coordinator"


### PR DESCRIPTION
## Issue
Fixes #61 


## Solution
instead of erroring out tempo-worker so that we don't try to restart the pebble service, override the shared worker's `restart` function to check if we don't have the config ready for the tempo-worker metrics-generator, don't restart and let `collect-unit-status` set the charm to blocked.


## Testing Instructions
Tandem PR: https://github.com/canonical/tempo-coordinator-k8s-operator/pull/127

