### PR TITLE
Add constraints TF input variable

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -101,6 +101,9 @@ Then, create a `constraints.tfvars` file with the following content:
 model_name = <model-name>
 constraints = "arch=<desired-arch> mem=<desired-memory>"
 ```
+> [!NOTE]
+> See [Juju constraints](https://documentation.ubuntu.com/juju/latest/reference/constraint/#list-of-constraints) for a list of available juju constraints.
+
 Then, use terraform to deploy the module:
 ```
 terraform init

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,6 +19,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `revision`| number | Revision number of the charm name | null |
 | `units`| number | Number of units to deploy | 1 |
+| `constraints`| string | String listing constraints for this application | arch=amd64 |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
@@ -34,7 +35,78 @@ Upon applied, the module exports the following outputs:
 > [!NOTE]
 > This module is intended to be used only in conjunction with its counterpart, [Tempo coordinator module](https://github.com/canonical/tempo-coordinator-k8s-operator) and, when deployed in isolation, is not functional. 
 > For the Tempo HA solution module deployment, check [Tempo HA module](https://github.com/canonical/observability)
+>
+> Additionally, a Juju model must be ready in advance.
 
-Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+### Basic usage
+In order to deploy this standalone module, create a `main.tf` file with the following content:
+```hcl
+module "tempo-worker" {
+  source      = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
+  model_name  = var.model_name
+  app_name    = var.app_name
+  channel     = var.channel
+  config      = var.config
+  revision    = var.revision
+  units       = var.units
+  constraints = var.constraints
+}
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "tempo-worker"
+}
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "latest/edge"
+}
+variable "config" {
+  description = "Charm config options as in the ones we pass in juju config"
+  type        = map(any)
+  default     = {}
+}
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}
+variable "units" {
+  description = "Number of units"
+  type        = number
+  default     = 1
+}
+variable "constraints" {
+  description = "Constraints for the charm deployment"
+  type        = string
+  default     = "arch=amd64"
+}
+```
+Then, use terraform to deploy the module:
+```
+terraform init
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```
 
-To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`
+### Deploy with constraints
+
+In order to deploy this module with a set of constraints (e.g: architecture, anti-affinity rules, etc.), create a `main.tf` similar to the [basic usage `main.tf` file](#basic-usage). 
+
+Then, create a `constraints.tfvars` file with the following content:
+```hcl
+model_name = <model-name>
+constraints = "arch=<desired-arch> mem=<desired-memory>"
+```
+Then, use terraform to deploy the module:
+```
+terraform init
+terraform apply -var-file=constraints.tfvars
+```
+> [!NOTE]
+> Any constraints must be prepended with "`arch=<desired-arch> `" for Terraform operations to work.
+>
+> See [Juju Terraform provider issue](https://github.com/juju/terraform-provider-juju/issues/344)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,10 +2,11 @@ resource "juju_application" "tempo_worker" {
 
   name = var.app_name
   # Coordinator and worker must be in the same model
-  model  = var.model_name
-  trust  = true
-  units  = var.units
-  config = var.config
+  model       = var.model_name
+  trust       = true
+  units       = var.units
+  config      = var.config
+  constraints = var.constraints
 
 
   charm {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,3 +32,13 @@ variable "units" {
   type        = number
   default     = 1
 }
+
+# We use constraints to set AntiAffinity in K8s
+# https://discourse.charmhub.io/t/pod-priority-and-affinity-in-juju-charms/4091/13?u=jose
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  # FIXME: Passing an empty constraints value to the Juju Terraform provider currently
+  # causes the operation to fail due to https://github.com/juju/terraform-provider-juju/issues/344
+  default = "arch=amd64"
+}


### PR DESCRIPTION
## Issue
Contributes to fixing https://github.com/canonical/tempo-worker-k8s-operator/issues/42


## Solution
- Add a `constraints` string var and pass it to the `juju_application` resource
- Update README with a section on how to use the `constraints` variable

## Context
- [Default value](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0) for the `constraints` var 

## Drive-bys
- Update README with a `basic usage` section that encourages users to use this module as a remote module.

## Testing Instructions
- Apply with no constraints given `terraform apply`
- Apply with constraints `terraform apply -var="constraints=arch=amd64 tags=anti-pod.app.kubernetes.io/name=tempo,anti-pod.topology-key=kubernetes.io/hostname"`
   - Then, `kubecttl get pod -n <model> tempo-worker-0 -o jsonpath='{.spec.affinity.podAntiAffinity}' `

## Upgrade Notes
This change is not 100% backwards-compatible since deploying this module on architectures other than `amd64` will now require passing a `-var="constraints=arch=<arch>"` to `terraform apply`
See more in https://github.com/juju/terraform-provider-juju/issues/344
